### PR TITLE
Fix issues when running in a docker container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This file is used to list changes made in each version of the apparmor cookbook.
 ## Unreleased
 
 - Fix issues when running in a docker container
+- Fix disabling apparmor on Ubuntu 18.04
 - Set `delay_mins` to 1 to help with CI problems
 
 ## 4.0.0 - *2021-09-15*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in each version of the apparmor cookbook.
 
 ## Unreleased
 
+- Fix issues when running in a docker container
+
 ## 4.0.0 - *2021-09-15*
 
 - Sous Chef Adoption

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This file is used to list changes made in each version of the apparmor cookbook.
 ## Unreleased
 
 - Fix issues when running in a docker container
+- Set `delay_mins` to 1 to help with CI problems
 
 ## 4.0.0 - *2021-09-15*
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -8,4 +8,6 @@ source_url        'https://github.com/sous-chefs/apparmor'
 issues_url        'https://github.com/sous-chefs/apparmor/issues'
 chef_version      '>= 15.3'
 
+depends 'line'
+
 supports 'ubuntu'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -28,7 +28,9 @@ if platform_family?('debian')
   execute 'apparmor_teardown' do
     command '/usr/sbin/service apparmor teardown'
     ignore_failure true
-    only_if { package_action == :remove && ::File.exist?('/lib/apparmor/functions') }
+    only_if do
+      package_action == :remove && ::File.exist?('/lib/apparmor/functions') && !docker?
+    end
   end
 
   package 'apparmor' do
@@ -45,7 +47,7 @@ if platform_family?('debian')
     action file_action
     notifies :run, 'execute[update-grub]'
     notifies :reboot_now, 'reboot[apparmor_state_change]' if node['apparmor']['automatic_reboot']
-    only_if { ::File.exist?('/etc/default/grub.d') }
+    not_if { docker? }
   end
 
   execute 'update-grub' do

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -45,6 +45,7 @@ if platform_family?('debian')
     action file_action
     notifies :run, 'execute[update-grub]'
     notifies :reboot_now, 'reboot[apparmor_state_change]' if node['apparmor']['automatic_reboot']
+    only_if { ::File.exist?('/etc/default/grub.d') }
   end
 
   execute 'update-grub' do

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -22,6 +22,7 @@ if platform_family?('debian')
   package_action = node['apparmor']['disable'] ? :remove : :install
   service_actions = node['apparmor']['disable'] ? [:stop, :disable] : [:start, :enable]
   file_action = node['apparmor']['disable'] ? :create : :delete
+  line_action = node['apparmor']['disable'] ? :edit : :nothing
 
   Chef::Log.info "package_action: #{package_action.inspect}"
 
@@ -47,7 +48,17 @@ if platform_family?('debian')
     action file_action
     notifies :run, 'execute[update-grub]'
     notifies :reboot_now, 'reboot[apparmor_state_change]' if node['apparmor']['automatic_reboot']
-    not_if { docker? }
+    not_if { docker? || !::Dir.exist?('/etc/default/grub.d') }
+  end
+
+  # Needed on older platforms that don't support /etc/default/grub.d
+  append_if_no_line 'disable apparmor' do
+    action line_action
+    path '/etc/default/grub'
+    line 'GRUB_CMDLINE_LINUX_DEFAULT="$GRUB_CMDLINE_LINUX_DEFAULT apparmor=0"'
+    notifies :run, 'execute[update-grub]'
+    notifies :reboot_now, 'reboot[apparmor_state_change]' if node['apparmor']['automatic_reboot']
+    not_if { docker? || ::Dir.exist?('/etc/default/grub.d') }
   end
 
   execute 'update-grub' do

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -55,6 +55,7 @@ if platform_family?('debian')
   end
 
   reboot 'apparmor_state_change' do
+    delay_mins 1
     reason 'Changing the AppArmor state requires a reboot'
     action :nothing
   end


### PR DESCRIPTION
By default containers will not have grub installed so the default recipe will fail. To work around this, only create the grub config file if the folder exists.

Signed-off-by: Lance Albertson <lance@osuosl.org>
