### PR TITLE
ci: test Cinc Workstation install action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ name: ci
 
 jobs:
   lint-unit:
-    uses: sous-chefs/.github/.github/workflows/lint-unit.yml@5.0.3
+    uses: sous-chefs/.github/.github/workflows/lint-unit.yml@feat/cinc-workstation-install
     permissions:
       actions: write
       checks: write
@@ -34,12 +34,11 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v5
-      - name: Install Chef
-        uses: actionshub/chef-install@main
+      - name: Install Workstation
+        uses: sous-chefs/.github/.github/actions/install-workstation@feat/cinc-workstation-install
       - name: Dokken
         uses: actionshub/test-kitchen@main
         env:
-          CHEF_LICENSE: accept-no-persist
           KITCHEN_LOCAL_YAML: kitchen.dokken.yml
         with:
           suite: ${{ matrix.suite }}
@@ -64,12 +63,11 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v5
-      - name: Install Chef
-        uses: actionshub/chef-install@main
+      - name: Install Workstation
+        uses: sous-chefs/.github/.github/actions/install-workstation@feat/cinc-workstation-install
       - name: test-kitchen
         uses: actionshub/test-kitchen@main
         env:
-          CHEF_LICENSE: accept-no-persist
           KITCHEN_LOCAL_YAML: kitchen.exec.yml
         with:
           suite: ${{ matrix.suite }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,11 +34,12 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v5
-      - name: Install Workstation
-        uses: sous-chefs/.github/.github/actions/install-workstation@feat/cinc-workstation-install
+      - name: Install Chef
+        uses: actionshub/chef-install@main
       - name: Dokken
         uses: actionshub/test-kitchen@main
         env:
+          CHEF_LICENSE: accept-no-persist
           KITCHEN_LOCAL_YAML: kitchen.dokken.yml
         with:
           suite: ${{ matrix.suite }}

--- a/kitchen.exec.yml
+++ b/kitchen.exec.yml
@@ -7,9 +7,8 @@ transport:
 
 provisioner:
   name: chef_infra
-  product_name: chef
+  product_name: cinc
   product_version: <%= ENV['CHEF_VERSION'] || 'latest' %>
-  chef_license: accept-no-persist
   multiple_converge: 2
   enforce_idempotency: true
   deprecations_as_errors: true

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -3,9 +3,8 @@ driver:
 
 provisioner:
   name: chef_infra
-  product_name: chef
+  product_name: cinc
   product_version: <%= ENV['CHEF_VERSION'] || 'latest' %>
-  chef_license: accept-no-persist
   multiple_converge: 2
   enforce_idempotency: true
   deprecations_as_errors: true


### PR DESCRIPTION
Test PR to validate the new Cinc Workstation install action from sous-chefs/.github#54.

Replaces `actionshub/chef-install` with `sous-chefs/.github/.github/actions/install-workstation` which uses `omnitruck.cinc.sh` instead of `omnitruck.chef.io`.

Points at `feat/cinc-workstation-install` branch for testing. Once validated, the shared workflow PR will be merged and all cookbooks can switch to `@main`.