### PR TITLE
chore: migrate dependency resolution to Policyfile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ name: ci
 
 jobs:
   lint-unit:
-    uses: sous-chefs/.github/.github/workflows/lint-unit.yml@8.0.2
+    uses: sous-chefs/.github/.github/workflows/lint-unit.yml@8.0.4
     permissions:
       actions: write
       checks: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,4 +84,4 @@ jobs:
     runs-on: ubuntu-latest
     needs: [integration-dokken, integration-exec]
     steps:
-      - run: echo ${{needs.integration-dokken.outputs}} ${{needs.integration-exec.outputs}}
+      - run: echo "${{ needs.integration-dokken.result }} ${{ needs.integration-exec.result }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,10 +34,10 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v7
-      - name: Install Chef
-        uses: actionshub/chef-install@main
+      - name: Install Cinc Workstation
+        uses: sous-chefs/.github/.github/actions/install-workstation@8.0.4
       - name: Dokken
-        uses: actionshub/test-kitchen@main
+        uses: actionshub/test-kitchen@3.0.0
         env:
           CHEF_LICENSE: accept-no-persist
           KITCHEN_LOCAL_YAML: kitchen.dokken.yml
@@ -64,10 +64,10 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v7
-      - name: Install Chef
-        uses: actionshub/chef-install@main
+      - name: Install Cinc Workstation
+        uses: sous-chefs/.github/.github/actions/install-workstation@8.0.4
       - name: test-kitchen
-        uses: actionshub/test-kitchen@main
+        uses: actionshub/test-kitchen@3.0.0
         env:
           CHEF_LICENSE: accept-no-persist
           KITCHEN_LOCAL_YAML: kitchen.exec.yml

--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -7,7 +7,7 @@ name: 'Validate PR'
 
 jobs:
   conventional-commits:
-    uses: sous-chefs/.github/.github/workflows/conventional-commits.yml@8.0.2
+    uses: sous-chefs/.github/.github/workflows/conventional-commits.yml@8.0.4
     permissions:
       pull-requests: read
     secrets: inherit

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -19,6 +19,6 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v7
       - name: Install Chef
-        uses: actionshub/chef-install@main
+        uses: sous-chefs/.github/.github/actions/install-workstation@8.0.4
       - name: Install cookbooks
-        run: berks install
+        run: chef install Policyfile.rb

--- a/.github/workflows/prevent-file-change.yml
+++ b/.github/workflows/prevent-file-change.yml
@@ -7,7 +7,7 @@ name: 'Prevent file change'
 
 jobs:
   prevent-file-change:
-    uses: sous-chefs/.github/.github/workflows/prevent-file-change.yml@8.0.2
+    uses: sous-chefs/.github/.github/workflows/prevent-file-change.yml@8.0.4
     permissions:
       pull-requests: write
     secrets:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   release:
-    uses: sous-chefs/.github/.github/workflows/release-cookbook.yml@8.0.2
+    uses: sous-chefs/.github/.github/workflows/release-cookbook.yml@8.0.4
     secrets:
       token: ${{ secrets.PORTER_GITHUB_TOKEN }}
       supermarket_user: ${{ secrets.CHEF_SUPERMARKET_USER }}

--- a/.gitignore
+++ b/.gitignore
@@ -36,7 +36,6 @@ doc/
 rdoc
 
 # chef infra stuff
-Berksfile.lock
 .kitchen
 kitchen.local.yml
 vendor/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,10 +19,10 @@ needed.
 
 ### APT (Debian/Ubuntu)
 
-- Debian 12 (Bookworm): apparmor 3.0.x (all architectures: amd64, arm64, armhf, i386, etc.)
-- Debian 13 (Trixie): apparmor 4.x (all architectures)
-- Ubuntu 22.04 (Jammy): apparmor 3.0.x (amd64, arm64, armhf, s390x, etc.)
-- Ubuntu 24.04 (Noble): apparmor 4.x (amd64, arm64, armhf, s390x, etc.)
+* Debian 12 (Bookworm): apparmor 3.0.x (all architectures: amd64, arm64, armhf, i386, etc.)
+* Debian 13 (Trixie): apparmor 4.x (all architectures)
+* Ubuntu 22.04 (Jammy): apparmor 3.0.x (amd64, arm64, armhf, s390x, etc.)
+* Ubuntu 24.04 (Noble): apparmor 4.x (amd64, arm64, armhf, s390x, etc.)
 
 ### Other Platform Families
 
@@ -41,7 +41,7 @@ The userspace tools are installed via the distribution package manager.
 
 ## Known Issues
 
-- Disabling AppArmor requires a GRUB configuration change and a reboot to take effect at the
+* Disabling AppArmor requires a GRUB configuration change and a reboot to take effect at the
   kernel level. The `apparmor_service` resource handles this via GRUB config and optional reboot.
-- In Docker containers, AppArmor is managed by the host. GRUB configuration changes are skipped
+* In Docker containers, AppArmor is managed by the host. GRUB configuration changes are skipped
   inside containers.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,15 @@
-# Limitations
+# AGENTS.md
+
+## Cookbook Purpose
+
+Provides apparmor_service and apparmor_policy resources
+
+## Agent Findings
+
+* This cookbook is in an incremental modernization pass. Preserve existing public recipes and attributes unless a later full migration is explicitly selected.
+* Dependency management should use `Policyfile.rb`; do not reintroduce Berkshelf.
+
+## Known Limitations
 
 ## Package Availability
 

--- a/Berksfile
+++ b/Berksfile
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-source 'https://supermarket.chef.io'
-
-metadata
-
-group :integration do
-  cookbook 'test', path: 'test/cookbooks/test'
-end

--- a/Policyfile.rb
+++ b/Policyfile.rb
@@ -10,5 +10,5 @@ cookbook 'test', path: './test/cookbooks/test'
 Dir.children('./test/cookbooks/test/recipes').grep(/\.rb\z/).sort.each do |recipe|
   recipe_name = File.basename(recipe, '.rb')
 
-  named_run_list recipe_name.to_sym, 'test::' + recipe_name
+  named_run_list recipe_name.to_sym, 'recipe[test::' + recipe_name + ']'
 end

--- a/Policyfile.rb
+++ b/Policyfile.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+name 'apparmor'
+
+run_list 'recipe[test::default]'
+
+cookbook 'apparmor', path: '.'
+cookbook 'test', path: './test/cookbooks/test'
+
+Dir.children('./test/cookbooks/test/recipes').grep(/\.rb\z/).sort.each do |recipe|
+  recipe_name = File.basename(recipe, '.rb')
+
+  named_run_list recipe_name.to_sym, 'test::' + recipe_name
+end

--- a/chefignore
+++ b/chefignore
@@ -85,8 +85,6 @@ test/*
 
 # Berkshelf #
 #############
-Berksfile
-Berksfile.lock
 cookbooks/*
 tmp
 

--- a/kitchen.exec.yml
+++ b/kitchen.exec.yml
@@ -7,7 +7,10 @@ transport:
 
 provisioner:
   name: chef_infra
+  product_name: cinc
   chef_omnibus_install: false
+  install_strategy: skip
+  chef_client_path: /opt/cinc-workstation/bin/chef-client
   sudo: true
   multiple_converge: 2
   enforce_idempotency: true

--- a/kitchen.exec.yml
+++ b/kitchen.exec.yml
@@ -7,9 +7,8 @@ transport:
 
 provisioner:
   name: chef_infra
-  product_name: chef
-  product_version: <%= ENV['CHEF_VERSION'] || 'latest' %>
-  chef_license: accept-no-persist
+  chef_omnibus_install: false
+  sudo: true
   multiple_converge: 2
   enforce_idempotency: true
   deprecations_as_errors: true

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -26,6 +26,8 @@ platforms:
 
 suites:
   - name: default
+    provisioner:
+      named_run_list: default
     run_list:
       - recipe[test::default]
     # verifier:
@@ -33,16 +35,19 @@ suites:
     #     - path: test/integration/default
 
   - name: disable
-    run_list:
-      - recipe[test::disable]
     provisioner:
+      named_run_list: disable
       max_retries: 60
       wait_for_retry: 90
+    run_list:
+      - recipe[test::disable]
     # verifier:
     #   inspec_tests:
     #     - path: test/integration/disable
 
   - name: policy-add
+    provisioner:
+      named_run_list: policy_add
     run_list:
       - recipe[test::policy_add]
     # verifier:
@@ -50,11 +55,12 @@ suites:
     #     - path: test/integration/policy-add
 
   - name: policy-remove
-    run_list:
-      - recipe[test::policy_remove]
     provisioner:
+      named_run_list: policy_remove
       multiple_converge: 1
       enforce_idempotency: false
+    run_list:
+      - recipe[test::policy_remove]
     # verifier:
     #   inspec_tests:
     #     - path: test/integration/policy-remove

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'chefspec'
-require 'chefspec/berkshelf'
+require 'chefspec/policyfile'
 
 RSpec.configure do |config|
   config.color = true               # Use color in STDOUT

--- a/test/integration/default/inspec.yml
+++ b/test/integration/default/inspec.yml
@@ -5,5 +5,3 @@ maintainer: Sous Chefs
 license: Apache-2.0
 summary: Verify AppArmor is installed and running
 version: 1.0.0
-supports:
-  - platform-family: debian

--- a/test/integration/disable/inspec.yml
+++ b/test/integration/disable/inspec.yml
@@ -5,5 +5,3 @@ maintainer: Sous Chefs
 license: Apache-2.0
 summary: Verify AppArmor is disabled and removed
 version: 1.0.0
-supports:
-  - platform-family: debian

--- a/test/integration/policy-add/inspec.yml
+++ b/test/integration/policy-add/inspec.yml
@@ -5,5 +5,3 @@ maintainer: Sous Chefs
 license: Apache-2.0
 summary: Verify AppArmor policy is added and loaded
 version: 1.0.0
-supports:
-  - platform-family: debian

--- a/test/integration/policy-remove/inspec.yml
+++ b/test/integration/policy-remove/inspec.yml
@@ -5,5 +5,3 @@ maintainer: Sous Chefs
 license: Apache-2.0
 summary: Verify AppArmor policy is removed
 version: 1.0.0
-supports:
-  - platform-family: debian


### PR DESCRIPTION
## Summary
- migrate dependency resolution from Berksfile to Policyfile
- update ChefSpec setup to use Policyfile resolution
- update CI/Copilot workflow references to current sous-chefs workflow/action versions
- move cookbook limitations into AGENTS.md where present

## Verification
- chef install Policyfile.rb
- cookstyle
- /opt/chef-workstation/embedded/bin/rspec --format progress
- kitchen list